### PR TITLE
Split ingress certs

### DIFF
--- a/artifacts/operator-amd64.yaml
+++ b/artifacts/operator-amd64.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: ingress-operator
       containers:
       - name: operator
-        image: openfaas/ingress-operator:0.2.0
+        image: openfaas/ingress-operator:0.2.1
         imagePullPolicy: Always
         command:
           - ./ingress-operator

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -274,7 +274,7 @@ func (c *Controller) syncHandler(key string) error {
 	var createCert bool
 
 	if function.Spec.TLS {
-		certName := function.ObjectMeta.Name + "certificate"
+		certName := function.ObjectMeta.Name + "-certificate"
 		_, err := c.cmclientset.Certificates(function.ObjectMeta.Namespace).Get(certName, v1.GetOptions{})
 		notFound := errors.IsNotFound(gotErr)
 		if err != nil && !notFound {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -492,6 +492,7 @@ func makeTLS(function *faasv1.FunctionIngress) []v1beta1.IngressTLS {
 
 func getClass(ingressType string) string {
 	switch ingressType {
+	case "":
 	case "nginx":
 		return "nginx"
 	default:


### PR DESCRIPTION
23fdf42 Update YAML deployment version
3aa7f12 Default Nginx for ingress class
cc3f0a6 Add skipper support
4420e18 Split creation of ingress / certs

Adds skipper support for the Zalando IngressController.
