### PR TITLE
Copy over annotations to ingress

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -473,10 +473,12 @@ func getClass(ingressType string) string {
 func makeAnnotations(function *faasv1.FunctionIngress) map[string]string {
 	class := getClass(function.Spec.IngressType)
 	specJSON, _ := json.Marshal(function)
-	annotations := map[string]string{
-		"kubernetes.io/ingress.class": class,
-		"com.openfaas.spec":           string(specJSON),
+	annotations := make(map[string]string)
+	for k, v := range function.ObjectMeta.Annotations {
+		annotations[k] = v
 	}
+	annotations["kubernetes.io/ingress.class"] = class
+	annotations["com.openfaas.spec"] = string(specJSON)
 
 	switch class {
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	faasv1 "github.com/openfaas-incubator/ingress-operator/pkg/apis/openfaas/v1alpha2"
+)
+
+func TestMakeAnnotations_AnnotationsCopied(t *testing.T) {
+	ingress := faasv1.FunctionIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"test":    "test",
+				"example": "example",
+			},
+		},
+	}
+
+	result := makeAnnotations(&ingress)
+
+	if _, ok := result["test"]; !ok {
+		t.Errorf("Failed to find expected annotation 'test'")
+	}
+	if _, ok := result["example"]; !ok {
+		t.Errorf("Failed to find expected annotation 'example'")
+	}
+}
+
+func TestMakeAnnotations_IngressClass(t *testing.T) {
+	ingress := faasv1.FunctionIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "not an ingress class",
+			},
+		},
+		Spec: faasv1.FunctionIngressSpec{
+			IngressType: "nginx",
+		},
+	}
+
+	result := makeAnnotations(&ingress)
+
+	if val, ok := result["kubernetes.io/ingress.class"]; !ok || val != "nginx" {
+		t.Errorf("Failed to find expected ingress class annotation. Expected 'nginx' but got '%s'", val)
+	}
+}
+
+func TestMakeAnnotations_IngressClassAdditionalAnnotations(t *testing.T) {
+	ingress := faasv1.FunctionIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+		Spec: faasv1.FunctionIngressSpec{
+			IngressType: "nginx",
+		},
+	}
+
+	result := makeAnnotations(&ingress)
+
+	if _, ok := result["nginx.ingress.kubernetes.io/rewrite-target"]; !ok {
+		t.Errorf("Failed to find expected rewrite-target annotation")
+	}
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -29,25 +29,27 @@ func TestMakeAnnotations_AnnotationsCopied(t *testing.T) {
 }
 
 func TestMakeAnnotations_IngressClass(t *testing.T) {
+	wantIngressType := "nginx"
 	ingress := faasv1.FunctionIngress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"kubernetes.io/ingress.class": "not an ingress class",
+				"kubernetes.io/ingress.class": "traefik",
 			},
 		},
 		Spec: faasv1.FunctionIngressSpec{
-			IngressType: "nginx",
+			IngressType: wantIngressType,
 		},
 	}
 
 	result := makeAnnotations(&ingress)
 
-	if val, ok := result["kubernetes.io/ingress.class"]; !ok || val != "nginx" {
-		t.Errorf("Failed to find expected ingress class annotation. Expected 'nginx' but got '%s'", val)
+	if val, ok := result["kubernetes.io/ingress.class"]; !ok || val != wantIngressType {
+		t.Errorf("Failed to find expected ingress class annotation. Expected '%s' but got '%s'", wantIngressType, val)
 	}
 }
 
 func TestMakeAnnotations_IngressClassAdditionalAnnotations(t *testing.T) {
+	defaultRewriteAnnotation := "nginx.ingress.kubernetes.io/rewrite-target"
 	ingress := faasv1.FunctionIngress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
@@ -59,7 +61,7 @@ func TestMakeAnnotations_IngressClassAdditionalAnnotations(t *testing.T) {
 
 	result := makeAnnotations(&ingress)
 
-	if _, ok := result["nginx.ingress.kubernetes.io/rewrite-target"]; !ok {
+	if _, ok := result[defaultRewriteAnnotation]; !ok {
 		t.Errorf("Failed to find expected rewrite-target annotation")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Marcus Noble <m.noble@elsevier.com>

## Description
Copy the annotations from FunctionIngress to the Ingress object that gets created so that ingress-specific annotations can be used (for example marking the ingress as being internal)

## Motivation and Context
I am currently looking to expose a function within out work network, using an internal ALB but an annotation on the ingress resource is needed for this.


## How Has This Been Tested?

Test yaml:

```
apiVersion: openfaas.com/v1alpha2
kind: FunctionIngress
metadata:
  name: example
  namespace: openfaas
  annotations:
    zalando.org/aws-load-balancer-scheme: internal
spec:
  domain: example.test.com
  function: example
  ingressType: skipper
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->
There shouldn't be any impact.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
