### PR TITLE
Add support for Kind in TLS Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Exploring the schema:
 
 * `issuerRef` which issuer to use, this may be a staging or production issuer.
 
+* `issuerRef.kind` Issuer or ClusterIssuer, This depends on whats available in your cluster
+
 ## Status
 
 This is work-in-progress prototype and only suitable for development and testing. Contributions and suggestions are welcome.
@@ -183,6 +185,24 @@ spec:
     http01: {}
 ```
 
+or ClusterIssuer
+
+```yaml
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: <your-email-here>
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    http01: {}
+```
+
 Save as `letsencrypt-issuer.yaml` then run `kubectl apply -f letsencrypt-issuer.yaml`.
 
 ### Run or deploy the IngressOperator
@@ -222,6 +242,9 @@ spec:
     enabled: true
     issuerRef:
       name: "letsencrypt-staging"
+      # Change to ClusterIssuer if required
+      # https://docs.cert-manager.io/en/latest/reference/clusterissuers.html
+      # https://docs.cert-manager.io/en/latest/reference/issuers.html
       kind: "Issuer"
 ```
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -470,6 +470,17 @@ func getClass(ingressType string) string {
 	return "nginx"
 }
 
+func getIssuerKind(issuerType string) string {
+	switch issuerType {
+	case "ClusterIssuer":
+		return "certmanager.k8s.io/cluster-issuer"
+		break
+	default:
+		return "certmanager.k8s.io/issuer"
+	}
+	return "certmanager.k8s.io/issuer"
+}
+
 func makeAnnotations(function *faasv1.FunctionIngress) map[string]string {
 	class := getClass(function.Spec.IngressType)
 	specJSON, _ := json.Marshal(function)
@@ -495,7 +506,8 @@ func makeAnnotations(function *faasv1.FunctionIngress) map[string]string {
 	}
 
 	if function.Spec.UseTLS() {
-		annotations["certmanager.k8s.io/issuer"] = function.Spec.TLS.IssuerRef.Name
+		issuerType := getIssuerKind(function.Spec.TLS.IssuerRef.Kind)
+		annotations[issuerType] = function.Spec.TLS.IssuerRef.Name
 		annotations["certmanager.k8s.io/acme-challenge-type"] = "http01"
 	}
 


### PR DESCRIPTION
Signed-off-by: Keiran Smith <contact@keiran.scot>

Add support for ClusterIssuer by following the issuerRef Kind

## Description
Uses a switch to determine the correct annotation based on TLS issuerRef

## Motivation and Context
Fixes issue #8 


## How Has This Been Tested?
Tested on personal cluster


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->
Nothing

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
