### PR TITLE
apiVersions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Now create an issuer:
 
 ```yaml
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: letsencrypt-staging
@@ -190,7 +190,7 @@ spec:
 or ClusterIssuer
 
 ```yaml
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging


### PR DESCRIPTION
Rename apiVersion from certmanager.k8s.io/v1alpha1 to cert-manager.io/v1alpha2

Signed-off-by: Christian Sakshaug <christian@dx.no>
