### PR TITLE
Print columns for CRD with -o wide

### DIFF
--- a/artifacts/operator-crd.yaml
+++ b/artifacts/operator-crd.yaml
@@ -16,6 +16,21 @@ spec:
     shortNames:
     - fni
   scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Domain
+    type: string
+    JSONPath: .spec.domain
+  - name: Function
+    type: string
+    JSONPath: .spec.function
+  - name: IngressType
+    type: string
+    JSONPath: .spec.ingressType
+  - name: TLS
+    type: boolean
+    JSONPath: .spec.tls.enabled
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When users run get fni -o wide, they can now see each of the
most important columns in their kubectl output.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Example

```
kosmos:ingress-operator alex$ kubectl get fni -o wide -A
NAMESPACE   NAME                       DOMAIN                 FUNCTION            INGRESSTYPE   TLS
openfaas    book-openfaas-io-tls       book.openfaas.io       openfaas-calendar   nginx         true
openfaas    insiders-openfaas-io-tls   insiders.openfaas.io   openfaas-insiders   nginx         true
openfaas    slack-openfaas-io-tls      slack.openfaas.io      openfaas-slack      nginx         true
openfaas    zoom-openfaas-io-tls       zoom.openfaas.io       openfaas-zoom       nginx         true
```
