### PR TITLE
Update custom annotation order

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,28 @@ If you are confident in the configuration, switch over to the production issuer,
 
 Save the file and apply.
 
+### Custom annotations
+
+You can also set custom annotations to be passed down to the Ingress record created by the operator.
+
+Example:
+
+This example adds one of the required annotations for basic auth as defined in the [ingress-nginx docs](https://kubernetes.github.io/ingress-nginx/examples/auth/basic/).
+
+```yaml
+apiVersion: openfaas.com/v1alpha2
+kind: FunctionIngress
+metadata:
+  name: nodeinfo
+  namespace: openfaas
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+spec:
+  domain: "nodeinfo.myfaas.club"
+  function: "nodeinfo"
+  ingressType: "nginx"
+```
+
 ### Bypass mode
 
 The IngressOperator can be used to create Ingress records that bypass the OpenFaaS Gateway. This may be useful when you are running a non-standard workload such as a brownfields monolith to reduce hops, or with an unsupported protocol like gRPC or websockets.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -28,13 +28,31 @@ func TestMakeAnnotations_AnnotationsCopied(t *testing.T) {
 	}
 }
 
-func TestMakeAnnotations_IngressClass(t *testing.T) {
+func TestMakeAnnotations_IngressClassCanOverride(t *testing.T) {
 	wantIngressType := "nginx"
 	ingress := faasv1.FunctionIngress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"kubernetes.io/ingress.class": "traefik",
+				"kubernetes.io/ingress.class": wantIngressType,
 			},
+		},
+		Spec: faasv1.FunctionIngressSpec{
+			IngressType: wantIngressType,
+		},
+	}
+
+	result := makeAnnotations(&ingress)
+
+	if val, ok := result["kubernetes.io/ingress.class"]; !ok || val != wantIngressType {
+		t.Errorf("Failed to find expected ingress class annotation. Expected '%s' but got '%s'", wantIngressType, val)
+	}
+}
+
+func TestMakeAnnotations_IngressClassDefaultsToNginx(t *testing.T) {
+	wantIngressType := "nginx"
+	ingress := faasv1.FunctionIngress{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
 		},
 		Spec: faasv1.FunctionIngressSpec{
 			IngressType: wantIngressType,


### PR DESCRIPTION
Enable custom annotations

This patch fixes #28 where a user requested to add their own
custom annotation to set additional configuration on the
Ingress record created by the operator. The change alters the 
order in which the custom annotations are applied.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>