### PR TITLE
Fix traefik annotations as they are not working properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,10 @@ spec:
 ```
 
 * Edit the `email` and take note of the `namespace`, you will want this to be `openfaas`.
-* If using `traefik` instead of `nginx`, then edit `class: nginx` and replace it as necessary
+* If using `traefik` instead of `nginx`, then edit `class: nginx` and replace it as necessary.
+  **Recommended version is v1.7.21 or above**, previous versions will incorrectly route requests
+  to your function (with duplicated path, see
+  [related issue](https://github.com/openfaas-incubator/ingress-operator/issues/30)).
 
 Save as `letsencrypt-issuer.yaml` then run `kubectl apply -f letsencrypt-issuer.yaml`.
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -429,7 +429,12 @@ func makeRules(fni *faasv1.FunctionIngress) []v1beta1.IngressRule {
 	}
 
 	if getClass(fni.Spec.IngressType) == "traefik" {
-		path = strings.TrimRight(path, "(.*)")
+		// We have to trim the regex and the trailing slash for Traefik,
+		// otherwise routing won't work
+		path = strings.TrimRight(path, "/(.*)")
+		if len(path) == 0 {
+			path = "/"
+		}
 	}
 
 	serviceHost := "gateway"
@@ -513,7 +518,7 @@ func makeAnnotations(fni *faasv1.FunctionIngress) map[string]string {
 			annotations["zalando.org/skipper-filter"] = `setPath("/function/` + fni.Spec.Function + `")`
 			break
 		case "traefik":
-			annotations["traefik.ingress.kubernetes.io/rewrite-target"] = "/function/" + fni.Spec.Function + "/$1"
+			annotations["traefik.ingress.kubernetes.io/rewrite-target"] = "/function/" + fni.Spec.Function
 			annotations["traefik.ingress.kubernetes.io/rule-type"] = `PathPrefix`
 			break
 		}


### PR DESCRIPTION
Signed-off-by: Aleksandr Fofanov <avl.fofanov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Please see the detailed description of the issue and context in #30

I've tested the changes to the annotation with the following function ingresses:
1.  Same as in the issue mentioned above
```
apiVersion: openfaas.com/v1alpha2
kind: FunctionIngress
metadata:
  name: podinfo
  namespace: dev-openfaas
spec:
  function: podinfo
  domain: podinfo.local.dev
  ingressType: "traefik"
  bypassGateway: false
  tls:
    enabled: false
```
Urls tested:
- http://podinfo.local.dev
- http://podinfo.local.dev/
- http://podinfo.local.dev/version
- http://podinfo.local.dev/delay/3
- http://podinfo.local.dev/swagger.json
- http://podinfo.local.dev/swagger/index.html

2. Function ingress with custom path
```
apiVersion: openfaas.com/v1alpha2
kind: FunctionIngress
metadata:
  name: podinfo
  namespace: dev-openfaas
spec:
  function: podinfo
  domain: podinfo.local.dev
  ingressType: "traefik"
  path: "/v1/(*.)"
  bypassGateway: false
  tls:
    enabled: false
```
Urls tested:
- http://podinfo.local.dev/v1
- http://podinfo.local.dev/v1/
- http://podinfo.local.dev/v1/version
- http://podinfo.local.dev/v1/delay/3
- http://podinfo.local.dev/v1/swagger.json
- http://podinfo.local.dev/v1/swagger/index.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #30

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've added the test that verifies that operator produce correct annotations for Traefik ingresses.
I also tested the changes to the annotations by following the steps described in #30

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->
This change shouldn't break anything in existing deployments.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
