### PR TITLE
Use the ingress domain for the tls secret

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -468,9 +468,11 @@ func makeTLS(fni *faasv1.FunctionIngress) []v1beta1.IngressTLS {
 	if !fni.Spec.UseTLS() {
 		return []v1beta1.IngressTLS{}
 	}
+
+
 	return []v1beta1.IngressTLS{
 		v1beta1.IngressTLS{
-			SecretName: fni.ObjectMeta.Name + "-cert",
+			SecretName: fni.Spec.Domain + "-cert",
 			Hosts: []string{
 				fni.Spec.Domain,
 			},
@@ -494,11 +496,9 @@ func getIssuerKind(issuerType string) string {
 	switch issuerType {
 	case "ClusterIssuer":
 		return "cert-manager.io/cluster-issuer"
-		break
 	default:
 		return "cert-manager.io/issuer"
 	}
-	return "cert-manager.io/issuer"
 }
 
 func makeAnnotations(fni *faasv1.FunctionIngress) map[string]string {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Change the name of the TLS secret to use the domain name. This allows
  multiple functions to use the same secret instead of creating multiple
  secrets. This reduces the complexity for REST style APIs that need
  multiple paths corresponding to multiple Functions and FunctionIngress
  on the same domain.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #34

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
new unit test

Manual testing locally with 
* ingress-operator using `theaxer/ingress-operator:latest-35`
* latest nginx-ingress
* latest cert-manager


A secret with the expected name `nodeinfo-tls.myfaas.club-cert-9q9wm` is created
```sh
$ kubectl get secret -n openfaas
NAME                                  TYPE                                  DATA   AGE
basic-auth                            Opaque                                2      12m
default-token-df84n                   kubernetes.io/service-account-token   3      19m
ingress-operator-token-m87z4          kubernetes.io/service-account-token   3      12m
nodeinfo-tls.myfaas.club-cert-9q9wm   Opaque                                1      60s
openfaas-controller-token-fhcsv       kubernetes.io/service-account-token   3      12m
openfaas-prometheus-token-7gd24       kubernetes.io/service-account-token   3      12m
sh.helm.release.v1.openfaas.v1        helm.sh/release.v1                    1      12m

$ kubectl get ing nodeinfo-tls -oyaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/issuer: letsencrypt-staging
    com.openfaas.spec: '{"metadata":{"name":"nodeinfo-tls","namespace":"openfaas","selfLink":"/apis/openfaas.com/v1alpha2/namespaces/openfaas/functioningresses/nodeinfo-tls","uid":"0e8c9e99-69b9-4ef5-bf8f-b0d421be2104","resourceVersion":"5069","generation":1,"creationTimestamp":"2020-10-31T16:56:16Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"openfaas.com/v1alpha2\",\"kind\":\"FunctionIngress\",\"metadata\":{\"annotations\":{},\"name\":\"nodeinfo-tls\",\"namespace\":\"openfaas\"},\"spec\":{\"domain\":\"nodeinfo-tls.myfaas.club\",\"function\":\"nodeinfo\",\"ingressType\":\"nginx\",\"path\":\"/\",\"tls\":{\"enabled\":true,\"issuerRef\":{\"kind\":\"Issuer\",\"name\":\"letsencrypt-staging\"}}}}\n"},"managedFields":[{"manager":"kubectl","operation":"Update","apiVersion":"openfaas.com/v1alpha2","time":"2020-10-31T16:56:16Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:domain":{},"f:function":{},"f:ingressType":{},"f:path":{},"f:tls":{".":{},"f:enabled":{},"f:issuerRef":{".":{},"f:kind":{},"f:name":{}}}}}}]},"spec":{"domain":"nodeinfo-tls.myfaas.club","function":"nodeinfo","path":"/","ingressType":"nginx","tls":{"enabled":true,"issuerRef":{"name":"letsencrypt-staging","kind":"Issuer"}}}}'
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openfaas.com/v1alpha2","kind":"FunctionIngress","metadata":{"annotations":{},"name":"nodeinfo-tls","namespace":"openfaas"},"spec":{"domain":"nodeinfo-tls.myfaas.club","function":"nodeinfo","ingressType":"nginx","path":"/","tls":{"enabled":true,"issuerRef":{"kind":"Issuer","name":"letsencrypt-staging"}}}}
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/rewrite-target: /function/nodeinfo/$1
  creationTimestamp: "2020-10-31T16:56:16Z"
  generation: 1
    manager: ingress-operator
    operation: Update
    time: "2020-10-31T16:56:16Z"
    manager: nginx-ingress-controller
    operation: Update
    time: "2020-10-31T16:56:55Z"
  name: nodeinfo-tls
  namespace: openfaas
  ownerReferences:
  - apiVersion: openfaas.com/v1alpha2
    blockOwnerDeletion: true
    controller: true
    kind: FunctionIngress
    name: nodeinfo-tls
    uid: 0e8c9e99-69b9-4ef5-bf8f-b0d421be2104
  resourceVersion: "5184"
  selfLink: /apis/extensions/v1beta1/namespaces/openfaas/ingresses/nodeinfo-tls
  uid: ebaa395f-6047-4cac-83a7-2f1a09b54d34
spec:
  rules:
  - host: nodeinfo-tls.myfaas.club
    http:
      paths:
      - backend:
          serviceName: gateway
          servicePort: 8080
        path: /
        pathType: ImplementationSpecific
  tls:
  - hosts:
    - nodeinfo-tls.myfaas.club
    secretName: nodeinfo-tls.myfaas.club-cert
status:
  loadBalancer:
    ingress:
    - ip: 172.20.0.2

kubectl get functioningress nodeinfo-tls  -oyaml
apiVersion: openfaas.com/v1alpha2
kind: FunctionIngress
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openfaas.com/v1alpha2","kind":"FunctionIngress","metadata":{"annotations":{},"name":"nodeinfo-tls","namespace":"openfaas"},"spec":{"domain":"nodeinfo-tls.myfaas.club","function":"nodeinfo","ingressType":"nginx","path":"/","tls":{"enabled":true,"issuerRef":{"kind":"Issuer","name":"letsencrypt-staging"}}}}
  creationTimestamp: "2020-10-31T16:56:16Z"
  generation: 1
  name: nodeinfo-tls
  namespace: openfaas
  resourceVersion: "5069"
  selfLink: /apis/openfaas.com/v1alpha2/namespaces/openfaas/functioningresses/nodeinfo-tls
  uid: 0e8c9e99-69b9-4ef5-bf8f-b0d421be2104
spec:
  domain: nodeinfo-tls.myfaas.club
  function: nodeinfo
  ingressType: nginx
  path: /
  tls:
    enabled: true
    issuerRef:
      kind: Issuer
      name: letsencrypt-staging
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Impact to existing users
<!-- What must existing users do to adopt this change? -->
- Existing FunctionIngress will recreate new secrets when this update is installed. Users may want to remove the existing secrets.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
