### PR TITLE
Make Path optional

### DIFF
--- a/artifacts/crds/openfaas.com_functioningresses.yaml
+++ b/artifacts/crds/openfaas.com_functioningresses.yaml
@@ -68,14 +68,10 @@ spec:
                   required:
                   - name
                   type: object
-              required:
-              - enabled
-              - issuerRef
               type: object
           required:
           - domain
           - function
-          - path
           type: object
       required:
       - spec
@@ -89,5 +85,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/pkg/apis/openfaas/v1alpha2/types.go
+++ b/pkg/apis/openfaas/v1alpha2/types.go
@@ -26,24 +26,30 @@ type FunctionIngressSpec struct {
 	Function string `json:"function"`
 
 	// Path such as "/v1/profiles/view/(.*)", or leave empty for default
+	// +optional
 	Path string `json:"path"`
 
 	// IngressType such as "nginx"
+	// +optional
 	IngressType string `json:"ingressType,omitempty"`
 
 	// Enable TLS via cert-manager
+	// +optional
 	TLS *FunctionIngressTLS `json:"tls,omitempty"`
 
 	// BypassGateway, when true creates an Ingress record
 	// directly for the Function name without using the gateway
 	// in the hot path
+	// +optional
 	BypassGateway bool `json:"bypassGateway,omitempty"`
 }
 
 // FunctionIngressTLS TLS options
 type FunctionIngressTLS struct {
+	// +optional
 	Enabled bool `json:"enabled"`
 
+	// +optional
 	IssuerRef ObjectReference `json:"issuerRef"`
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Make Path optional

## Motivation and Context

In 1ce6cda, Path was made a required field, but this was not
intended. This commit reverts the issue by adding an optional
header for kubebuilder. It also regenerates the YAML CRD.

#37 

## How Has This Been Tested?

@LucasRoesler do you want to try out the new YAML file with your testing cluster for #35 ?